### PR TITLE
Patched loader.py to retain exactly two days' worth of records in the DB

### DIFF
--- a/etl/load/loader.py
+++ b/etl/load/loader.py
@@ -44,6 +44,11 @@ def load_data(database_uri: str, data: list) -> bool:
             cursor.execute(insert_query, formatted_data)
             connection.commit()
 
+            # Delete records beyond 48 hours from the SQLite table
+            delete_query = f"DELETE FROM {schema['table']} WHERE datetime(timestamp) < datetime('now', '-48 hours')"
+            cursor.execute(delete_query)
+            connection.commit()
+
             return cursor.lastrowid > 0
 
     except sqlite3.Error as error_msg:

--- a/patch/loader_14062023_15_18.patch
+++ b/patch/loader_14062023_15_18.patch
@@ -1,0 +1,14 @@
+--- loader.py	2023-06-14 15:08:06.360030200 +0000
++++ loader-new.py	2023-06-14 15:10:53.652030200 +0000
+@@ -44,6 +44,11 @@
+             cursor.execute(insert_query, formatted_data)
+             connection.commit()
+ 
++            # Delete records beyond 48 hours from the SQLite table
++            delete_query = f"DELETE FROM {schema['table']} WHERE datetime(timestamp) < datetime('now', '-48 hours')"
++            cursor.execute(delete_query)
++            connection.commit()
++
+             return cursor.lastrowid > 0
+ 
+     except sqlite3.Error as error_msg:


### PR DESCRIPTION
**Patch update:** ETL program to delete data in SQLite db beyond the past 48 hours right after inserting new data. This is critically important to benchmark storage resource usage on https://www.pythonanywhere.com/ 's server to 48 hours at "every minute".