### PR TITLE
Updated code to retain only 48 hours' worth of data

### DIFF
--- a/etl/load/loader.py
+++ b/etl/load/loader.py
@@ -44,8 +44,11 @@ def load_data(database_uri: str, data: list) -> bool:
             cursor.execute(insert_query, formatted_data)
             connection.commit()
 
-            # Delete records beyond 48 hours from the SQLite table
-            delete_query = f"DELETE FROM {schema['table']} WHERE datetime(timestamp) < datetime('now', '-48 hours')"
+            # The maximum timestamp is the timestamp of the last inserted record
+            max_timestamp = formatted_data[0]
+
+            # Delete records beyond 48 hours from the maximum timestamp in the SQLite table
+            delete_query = f"DELETE FROM {schema['table']} WHERE datetime(timestamp) < datetime('{max_timestamp}', '-48 hours')"
             cursor.execute(delete_query)
             connection.commit()
 

--- a/patch/loader_16062023_12_34.patch
+++ b/patch/loader_16062023_12_34.patch
@@ -1,0 +1,16 @@
+--- loader.py	2023-06-16 10:54:58.201381900 +0000
++++ loader-new.py	2023-06-16 11:32:50.185381900 +0000
+@@ -44,8 +44,11 @@
+             cursor.execute(insert_query, formatted_data)
+             connection.commit()
+ 
+-            # Delete records beyond 48 hours from the SQLite table
+-            delete_query = f"DELETE FROM {schema['table']} WHERE datetime(timestamp) < datetime('now', '-48 hours')"
++            # The maximum timestamp is the timestamp of the last inserted record
++            max_timestamp = formatted_data[0]
++
++            # Delete records beyond 48 hours from the maximum timestamp in the SQLite table
++            delete_query = f"DELETE FROM {schema['table']} WHERE datetime(timestamp) < datetime('{max_timestamp}', '-48 hours')"
+             cursor.execute(delete_query)
+             connection.commit()
+ 


### PR DESCRIPTION
This issue #4 has been resolved

Closes #4 

```
sqlite> select * from bitcoin_rates limit 1;
980|2023-06-14T11:30:00+00:00|Bitcoin|25980.3902|21709.0062|25308.6932
sqlite> select * from bitcoin_rates order by unique_number desc limit 1;
2765|2023-06-16T11:30:00+00:00|Bitcoin|25453.3984|21268.6561|24795.3262
```